### PR TITLE
Send 503 error instead of 200 ok

### DIFF
--- a/src/ngx_http_testcookie_filter_module.c
+++ b/src/ngx_http_testcookie_filter_module.c
@@ -417,7 +417,7 @@ ngx_http_send_custom_refresh(ngx_http_request_t *r, ngx_http_testcookie_conf_t  
     ngx_chain_t   out;
     ngx_str_t     compiled_refresh_template;
 
-    r->err_status = NGX_HTTP_OK;
+    r->err_status = NGX_HTTP_SERVICE_UNAVAILABLE;
 
     r->headers_out.content_type_len = sizeof("text/html") - 1;
     r->headers_out.content_type.data = (u_char *) "text/html";
@@ -516,7 +516,7 @@ ngx_http_testcookie_handler(ngx_http_request_t *r)
     ctx = ngx_http_testcookie_get_uid(r, conf);
     if (ctx == NULL) {
 //        return NGX_DECLINED;
-        return NGX_HTTP_FORBIDDEN;
+        return NGX_HTTP_SERVICE_UNAVAILABLE;
     }
 
     if (conf->enable == NGX_HTTP_TESTCOOKIE_VAR) {
@@ -572,7 +572,7 @@ ngx_http_testcookie_handler(ngx_http_request_t *r)
         if (conf->max_attempts > 0 && attempt >= conf->max_attempts) {
             r->keepalive = 0;
             if (conf->fallback.len == 0) {
-                return NGX_HTTP_FORBIDDEN;
+                return NGX_HTTP_SERVICE_UNAVAILABLE;
             }
             if (conf->fallback_lengths != NULL && conf->fallback_values != NULL) {
                 if (ngx_http_script_run(r, &compiled_fallback, conf->fallback_lengths->elts,

--- a/src/ngx_http_testcookie_filter_module.c
+++ b/src/ngx_http_testcookie_filter_module.c
@@ -356,7 +356,7 @@ ngx_http_send_refresh(ngx_http_request_t *r)
            + escape + len
            + sizeof(ngx_http_msie_refresh_tail) - 1;
 
-    r->err_status = NGX_HTTP_OK;
+    r->err_status = NGX_HTTP_SERVICE_UNAVAILABLE;
 
     r->headers_out.content_type_len = sizeof("text/html") - 1;
     r->headers_out.content_type.len = sizeof("text/html") - 1;


### PR DESCRIPTION
When module is enable it modify content but send 200 ok. It is bad for SEO.
I suggest send 503 temporary unavailable for search bot come back later and didn't index bad content. 