### PR TITLE
Don't mention -lssl in CORE_LIBS, use USE_OPENSSL instead.

### DIFF
--- a/config
+++ b/config
@@ -3,4 +3,4 @@ HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_testcookie_filter_mod
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_testcookie_filter_module.c"
 NGX_ADDON_DEPS="$NGX_ADDON_DEPS"
 #CFLAGS="$CFLAGS"
-CORE_LIBS="$CORE_LIBS -lssl"
+USE_OPENSSL=YES


### PR DESCRIPTION
It will allow nginx to link with correct OpenSSL library, taking
--with-openssl into account. Otherwise, --with-openssl was caused
linking with two OpenSSL libraries.