### PR TITLE
Variable invalid in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -174,7 +174,7 @@ Available all the nginx variables and
 
     $testcookie_nexturl - URL the client should be redirected to, if max_attempts exceeded *testcookie_fallback* value will be here
     $testcookie_uid_got - cookie value received from client, empty if no cookie or it does not match format
-    $testcookie_uid_set - correct cookie value we're expecting from client
+    $testcookie_set - correct cookie value we're expecting from client // seems to only work using the $testcookie_set variable, not the $testcookie_uid_set
     $testcookie_ok - user passed test (1 - passed, 0 - not passed) Note: changed from "yes"/"no" in v1.10
 
 also, if testcookie_refresh_encrypt_cookie enabled there are three more variables:


### PR DESCRIPTION
Change $testcookie_uid_set to $testcookie_set (it seems to only work with the second one).