### PR TITLE
Disable implicit-fallthrough warnings

### DIFF
--- a/src/ngx_http_testcookie_access_module.c
+++ b/src/ngx_http_testcookie_access_module.c
@@ -2193,6 +2193,7 @@ ngx_http_testcookie_whitelist(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
 
 #if (NGX_HAVE_INET6)
     case AF_INET6:
+    /* fall through */
 
         for (i = 2; i; i--) {
             rc = ngx_radix128tree_insert(ucf->whitelist6, cidr.u.in6.addr.s6_addr,
@@ -2227,6 +2228,7 @@ ngx_http_testcookie_whitelist(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
 
 #endif
 
+    /* fall through */
     default: /* AF_INET */
 
         cidr.u.in.addr = ntohl(cidr.u.in.addr);


### PR DESCRIPTION
Fixes build with `-Werror=implicit-fallthrough`
```
extra/ngx_devel_kit/src -I debian/extra/ngx_devel_kit/objs -I objs/addon/ndk -I debian/extra/ngx_brotli/deps/brotli/include -I /usr/include/postgresql -I debian/extra/nchan/src -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I debian/extra/ngx_devel_kit/src -I src/mail -I src/stream \
	-o objs/addon/src/ngx_http_testcookie_access_module.o \
	debian/extra/testcookie-nginx-module/src/ngx_http_testcookie_access_module.c
debian/extra/testcookie-nginx-module/src/ngx_http_testcookie_access_module.c: In function 'ngx_http_testcookie_whitelist':
debian/extra/testcookie-nginx-module/src/ngx_http_testcookie_access_module.c:2187:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
         for (i = 2; i; i--) {
         ^~~
debian/extra/testcookie-nginx-module/src/ngx_http_testcookie_access_module.c:2220:5: note: here
     default: /* AF_INET */
     ^~~~~~~
cc1: all warnings being treated as errors
objs/Makefile:2706: recipe for target 'objs/addon/src/ngx_http_testcookie_access_module.o' failed
make[3]: *** [objs/addon/src/ngx_http_testcookie_access_module.o] Error 1
```