### PR TITLE
add Redis support

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,19 @@ DESCRIPTION
     be encrypted with AES-128 in CBC mode using custom/random key and iv,
     and then decrypted at client side with JavaScript.
 
+    If use Redis feature, only IPs which are stored in Redis need to resolve challenge, remaining is allowed (allow all but block some)
+    We can use any Redis client to dynamically add or new IP to blacklist without reloading Nginx. Example:
+    ## select DB which store blacklist
+    127.0.0.1:6379> SELECT 3
+
+    ##add new key-value to block permanent
+    127.0.0.1:6379> SET malicious_ip malicious_ip
+    or block in some times:
+    127.0.0.1:6379>SETEX malicious_ip blocktime_in_seconds malicious_ip
+
+    ### delete IP:
+    127.0.0.1:6379>DEL not_malicious_ip_anymore
+
 
 DIRECTIVES
 
@@ -138,9 +151,24 @@ DIRECTIVES
         default is off.
 
 
-INSTALLATION
+    testcookie_redis
+	if enable, only IPs in logical database number which configured in testcookie_redisdb is required to verify, all are allow
+        on - enable module, using Redis to store blacklist IPs
+        off - disable module with Redis intergration
+        var - don't intercept requests, only set cookie vars
 
-    Grab the nginx source code from nginx.org (<http://nginx.org/>), for
+    testcookie_redisip
+        Redis server's IP
+    
+    testcookie_redisport
+        Redis port
+    
+    testcookie_redisdb
+        Redis logical DB used for storing blacklist IPs
+
+INSTALLATION
+    
+    Install hiredis library, grab the nginx source code from nginx.org (<http://nginx.org/>), for
     example, the version 1.1.15 (see nginx compatibility), and then build
     the source with this module:
 
@@ -178,6 +206,13 @@ EXAMPLE CONFIGURATION
     http {
         #default config, module disabled
         testcookie off;
+	
+	#config for redis
+        testcookie_reis off;
+	testcookie_redisip 127.0.0.1;
+        testcookie_redisport 6379;
+        testcookie_redisdb 3;
+
 
         #setting cookie name
         testcookie_name BPC;
@@ -240,6 +275,15 @@ EXAMPLE CONFIGURATION
             location / {
                 #enable module for specific location
                 testcookie on;
+                proxy_set_header   Host             $host;
+                proxy_set_header   X-Real-IP        $remote_addr;
+                proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+                proxy_pass http://127.0.0.1:80;
+            }
+
+            location /dynamic_block {
+                #enable testcookie with redis support for this specific location, then we can dynamically add IP to block without reloading Nginx
+                testcookie_redis on;
                 proxy_set_header   Host             $host;
                 proxy_set_header   X-Real-IP        $remote_addr;
                 proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;

--- a/config
+++ b/config
@@ -1,4 +1,6 @@
 ngx_addon_name=ngx_http_testcookie_access_module
+ngx_waf_incs="/usr/local/include/hiredis"
+ngx_waf_libs="-lhiredis"
 
 # b/c it's a DDoS prevention module - we set module_type=HTTP_AUX_FILTER to run it ASAP
 # if you need some more logic, place the module near the other access phase modules
@@ -8,6 +10,8 @@ if test -n "$ngx_module_link"; then
     ngx_module_name=ngx_http_testcookie_access_module
     ngx_module_srcs="$ngx_addon_dir/src/ngx_http_testcookie_access_module.c"
     #ngx_module_order="$ngx_module_name ngx_http_access_module"
+         ngx_module_libs="$ngx_waf_libs"
+    ngx_module_incs="$ngx_waf_incs"
 
     . auto/module
 else
@@ -16,4 +20,6 @@ else
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS"
     #CFLAGS="$CFLAGS"
     USE_OPENSSL=YES
+         ngx_module_libs="$ngx_waf_libs"
+    ngx_module_incs="$ngx_waf_incs"
 fi

--- a/src/ngx_http_testcookie_access_module.c
+++ b/src/ngx_http_testcookie_access_module.c
@@ -624,7 +624,7 @@ ngx_http_testcookie_handler(ngx_http_request_t *r)
 				if (c) {
                     ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
 					"smt wrong Redis: %s\n", c->errstr);
-					return NGX_OK;
+					return NGX_DECLINED;
 				} else {
 					ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
 							"redis connection error: can't allocate redis context\n");
@@ -637,7 +637,7 @@ ngx_http_testcookie_handler(ngx_http_request_t *r)
 		reply = redisCommand(c, "GET %s", Host);
 		if (reply->str == NULL) {
 			freeReplyObject(reply);
-			return NGX_OK;
+			return NGX_DECLINED;
 		}
 
         ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,

--- a/src/ngx_http_testcookie_access_module.c
+++ b/src/ngx_http_testcookie_access_module.c
@@ -699,7 +699,7 @@ ngx_http_testcookie_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     } else {
 			ngx_log_error(conf->forbid_log_level, r->connection->log, 0,
-					"requests didn't passed testcookie module"); 
+					"requests didn't pass testcookie module"); 
     }
 
     args = &r->args;


### PR DESCRIPTION
 Hi kyprizel, I would like to say that this module is really incredible. I'm using it for almost all of my system which i manage. But, imo, there's still a small problem that, sometimes we need this module work in other way. Normally, the idea for verifying bot is to block all but allow some in whitelist, sometimes we will need it in opposite way, allow all, but block only some in blacklist, and this blacklist will need to be added/removed dynamically without reloading Nginx. Thinking about this, i did some changes to integrate this great module with Redis, we will store blacklist IP in Redis, then enable bot verification only if request's remote_add in this blacklist. Of course, this new feature is not conflict with the famous original one, we  can use original for some locations, and Redis feature for others, which need "allow all but block some" idea. 
I tested successfully with Nginx 1.16.0 and 1.14.2, other versions should work well, too. So, please consider this change, for a more flexible module.
Thanks!

On branch redis-support
 Changes to be committed:
	modified:   README
	modified:   src/ngx_http_testcookie_access_module.c