### PR TITLE
old behavior for cookies with cross-domain requests

### DIFF
--- a/README
+++ b/README
@@ -29,6 +29,11 @@ DIRECTIVES
     testcookie_path
         cookie path, useful if you plan to use different keys for locations. default is /
 
+    testcookie_samesite
+        cookie samesite attribute, allows you to declare if your cookie should be restricted 
+        to a first-party or same-site context. Default is None (Cookies will be sent in all contexts,
+        i.e sending cross-origin is allowed.) Accepts three values: Lax, Strict, None.
+
     testcookie_secret
         secret string, used in challenge cookie computation, should be 32 bytes or more,
         better to be long but static to prevent cookie reset for legitimate users every server restart.

--- a/README
+++ b/README
@@ -136,7 +136,7 @@ DIRECTIVES
     testcookie_secure_flag
         adds Secure flag for cookie (on|off|$variable)
         default is on.
-        any variable value except "off" interpreted as True.
+        any variable value except "on" interpreted as False.
 
     testcookie_port_in_redirect
         Keep server port in redirect (on|off)

--- a/README
+++ b/README
@@ -135,7 +135,7 @@ DIRECTIVES
 
     testcookie_secure_flag
         adds Secure flag for cookie (on|off|$variable)
-        default is off.
+        default is on.
         any variable value except "off" interpreted as True.
 
     testcookie_port_in_redirect

--- a/README.markdown
+++ b/README.markdown
@@ -314,7 +314,7 @@ testcookie_secure_flag
 ------------------------
 **syntax:** *testcookie_secure_flag (on|off|$variable);*
 
-**default:** *off*
+**default:** *on*
 
 **context:** *http, server, location*
 

--- a/README.markdown
+++ b/README.markdown
@@ -71,6 +71,18 @@ testcookie_path
 
 Sets cookie path, useful if you plan to use different keys for locations.
 
+testcookie_samesite
+---------------
+**syntax:** *testcookie_samesite &lt;string&gt;*
+
+**default:** *None*
+
+**context:** *http, server, location*
+
+Sets cookie attribute, allows you to declare if your cookie should be restricted to a first-party or same-site context.
+Default is None (Cookies will be sent in all contexts, i.e sending cross-origin is allowed.)
+Accepts values: Lax, Strict, None.
+
 testcookie_secret
 -----------------
 **syntax:** *testcookie_secret &lt;string&gt;*

--- a/README.markdown
+++ b/README.markdown
@@ -319,7 +319,7 @@ testcookie_secure_flag
 **context:** *http, server, location*
 
 Enable Secure flag for cookie.
-Any variable value except "off" interpreted as True.
+Any variable value except "on" interpreted as False.
 
 testcookie_port_in_redirect
 ---------------------------

--- a/src/ngx_http_testcookie_access_module.c
+++ b/src/ngx_http_testcookie_access_module.c
@@ -1414,7 +1414,7 @@ ngx_http_testcookie_set_uid(ngx_http_request_t *r, ngx_http_testcookie_ctx_t *ct
     u_char           *cookie, *p;
     size_t            len;
     ngx_table_elt_t  *set_cookie, *p3p;
-    ngx_uint_t        secure_flag_set = TESTCOOKIE_SECURE_FLAG_OFF;
+    ngx_uint_t        secure_flag_set = TESTCOOKIE_SECURE_FLAG_ON;
     ngx_str_t         secure_flag;
 
     if (conf->redirect_via_refresh && conf->refresh_template.len > 0) {

--- a/src/ngx_http_testcookie_access_module.c
+++ b/src/ngx_http_testcookie_access_module.c
@@ -1871,7 +1871,7 @@ ngx_http_testcookie_samesite(ngx_conf_t *cf, void *post, void *data)
     }
 
     p = ngx_cpymem(new, "; SameSite=", sizeof("; SameSite=") - 1);
-    ngx_memcpy(p, path->data, samesite->len);
+    ngx_memcpy(p, samesite->data, samesite->len);
 
     samesite->len += sizeof("; SameSite=") - 1;
     samesite->data = new;

--- a/src/ngx_http_testcookie_access_module.c
+++ b/src/ngx_http_testcookie_access_module.c
@@ -1446,9 +1446,10 @@ ngx_http_testcookie_set_uid(ngx_http_request_t *r, ngx_http_testcookie_ctx_t *ct
     if (conf->secure_flag != NULL
         && ngx_http_complex_value(r, conf->secure_flag, &secure_flag) == NGX_OK
         && secure_flag.len
-        && (secure_flag.len != 3 || secure_flag.data[2] != 'f' || secure_flag.data[1] != 'f' || secure_flag.data[0] != 'o'))
+        && (secure_flag.len != 2 || secure_flag.data[1] != 'n' || secure_flag.data[0] != 'o'))
     {
-        secure_flag_set = TESTCOOKIE_SECURE_FLAG_ON;
+        secure_flag_set = TESTCOOKIE_SECURE_FLAG_OFF;
+    } else {
         len += sizeof("; Secure") - 1;
     }
 


### PR DESCRIPTION
Retains the old behavior for sending cookies with cross-domain requests. Details https://www.chromium.org/updates/same-site